### PR TITLE
Fix: Correct duplicated project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ This release represents a complete architectural overhaul and project reorganiza
 - **🔄 Release Candidate Versioning**: Proper semantic versioning for testing phase
 
 ### Changed - MAJOR IMPROVEMENTS ⚡
-- **📦 Project Renamed**: "Whisper Appliance Appliance" → "OpenAI Whisper Web Interface"
+- **📦 Project Renamed**: "Whisper Appliance" → "OpenAI Whisper Web Interface"
 - **🏗️ Architecture Simplified**: From FastAPI + multiple backends → Flask + SocketIO
 - **📂 File Organization**: Scripts moved to `scripts/`, docs reorganized
 - **🔄 Development Workflow**: Updated for Flask-based development

--- a/CONTAINER-DEPLOYMENT.md
+++ b/CONTAINER-DEPLOYMENT.md
@@ -1,8 +1,8 @@
-# Whisper Appliance Appliance - Proxmox Container Deployment
+# Whisper Appliance - Proxmox Container Deployment
 
 ## 🎯 Container-First Approach
 
-This repository is optimized for **Proxmox LXC Container** deployment, providing a fast and reliable way to run the Whisper Appliance Appliance.
+This repository is optimized for **Proxmox LXC Container** deployment, providing a fast and reliable way to run the Whisper Appliance.
 
 ## 📋 Prerequisites
 

--- a/PROXMOX-QUICKSTART.md
+++ b/PROXMOX-QUICKSTART.md
@@ -1,4 +1,4 @@
-# 🎤 Whisper Appliance Appliance - Proxmox Quick Start
+# 🎤 Whisper Appliance - Proxmox Quick Start
 
 ## 🚀 5-Minuten-Deployment für Proxmox
 

--- a/README-FEATURES.md
+++ b/README-FEATURES.md
@@ -1,4 +1,4 @@
-# 🎤 Whisper Appliance Appliance - Feature Management System
+# 🎤 Whisper Appliance - Feature Management System
 
 ## 🎯 **Aktive Features & Projekte**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🎤 Whisper Appliance Appliance v1.1.0
+# 🎤 Whisper Appliance v1.1.0
 
 ## ⚠️ DEVELOPMENT STATUS
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-We actively support the following versions of Whisper Appliance Appliance:
+We actively support the following versions of Whisper Appliance:
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -12,7 +12,7 @@ We actively support the following versions of Whisper Appliance Appliance:
 
 ## Reporting a Vulnerability
 
-We take security vulnerabilities seriously. If you discover a security vulnerability in Whisper Appliance Appliance, please report it responsibly.
+We take security vulnerabilities seriously. If you discover a security vulnerability in Whisper Appliance, please report it responsibly.
 
 ### How to Report
 


### PR DESCRIPTION
Replaced instances of 'Whisper Appliance Appliance' with 'Whisper Appliance' in documentation files.