### PR TITLE
Fix: Correct AdminPanel method name for admin interface

### DIFF
--- a/src/modules/admin_panel.py
+++ b/src/modules/admin_panel.py
@@ -193,6 +193,8 @@ class AdminPanel:
     def get_demo_interface(self):
         """Demo interface stub"""
         return "<h1>Demo Interface - Coming Soon</h1>"
+
+    def get_admin_interface(self):
         """Generate admin interface without f-string CSS issues"""
         uptime = (datetime.now() - self.system_stats["uptime_start"]).total_seconds()
         uptime_formatted = f"{int(uptime // 3600)}h {int((uptime % 3600) // 60)}m {int(uptime % 60)}s"


### PR DESCRIPTION
Renamed the method responsible for generating the admin panel HTML from `get_demo_interface` to `get_admin_interface` in `src/modules/admin_panel.py`.

This resolves an AttributeError that occurred because the route in `main.py` was calling a non-existent `get_admin_interface` method.