### PR TITLE
Fix: Add /opt/whisper-appliance to git safe.directory in proxmox script

### DIFF
--- a/scripts/proxmox-standalone-git.sh
+++ b/scripts/proxmox-standalone-git.sh
@@ -138,6 +138,8 @@ fi
 print_status "Cloning WhisperS2T repository..."
 cd /opt
 git clone https://github.com/GaboCapo/whisper-appliance.git
+# Add /opt/whisper-appliance to safe directories
+git config --global --add safe.directory /opt/whisper-appliance
 chown -R whisper:whisper /opt/whisper-appliance
 
 print_status "Installing Python dependencies..."


### PR DESCRIPTION
This change modifies the proxmox-standalone-git.sh script to include the command `git config --global --add safe.directory /opt/whisper-appliance` during the installation process within the LXC container.

This prevents the 'fatal: detected dubious ownership in repository' error when a user later tries to `git pull` updates from within the container.