### PR TITLE
Fix: Correct import path for admin module in main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -49,7 +49,7 @@ try:
         ModelManager,
         UploadHandler,
     )
-    from src.admin import init_admin_panel # Added for the new admin panel
+    from admin import init_admin_panel # Added for the new admin panel
 
     print("✅ Core modules imported successfully")
 except ImportError as e:


### PR DESCRIPTION
Changed 'from src.admin import init_admin_panel' to 'from admin import init_admin_panel' in src/main.py to resolve ModuleNotFoundError when the script is executed from within the 'src' directory.