### PR TITLE
Fix: Correct Jinja2 template syntax error in admin dashboard

### DIFF
--- a/src/admin/templates/admin-dashboard.html
+++ b/src/admin/templates/admin-dashboard.html
@@ -1,3 +1,6 @@
+{% extends "admin-base.html" %}
+
+{% block content %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
The admin dashboard template had an orphaned `endblock` tag, causing a `TemplateSyntaxError`. This change ensures the template correctly extends `admin-base.html` and defines the `content` block properly.