### PR TITLE
Add manual update instructions to admin settings

### DIFF
--- a/src/admin/templates/admin-settings.html
+++ b/src/admin/templates/admin-settings.html
@@ -147,6 +147,13 @@
             <button class="btn btn-secondary mr-sm" id="installUpdateButton" onclick="installSystemUpdate()" style="display: none;">
                 Install Update
             </button>
+            <div class="mt-sm">
+                <small class="text-muted">
+                    To update Whisper Appliance in the future:<br>
+                    1. Enter container: <code>pct enter $CTID</code><br>
+                    2. Run: <code>cd /opt/whisper-appliance && git pull && systemctl restart whisper-appliance</code>
+                </small>
+            </div>
             <button class="btn btn-warning" id="restartAppButton" onclick="restartApplication()" style="display: none;">
                 Restart Application
             </button>


### PR DESCRIPTION
This commit adds a help text section below the 'Install Update' button in the admin settings page. The text provides instructions for manually updating the Whisper Appliance via the command line.