### PR TITLE
feat: Add logs section to admin panel

### DIFF
--- a/communication_logs.json
+++ b/communication_logs.json
@@ -1,0 +1,8 @@
+[
+    {
+        "timestamp": "2023-10-27T10:00:00.000000",
+        "user_input": "Test user input",
+        "model": "test_model",
+        "response": "Test model response"
+    }
+]

--- a/src/admin/admin_panel.py
+++ b/src/admin/admin_panel.py
@@ -74,7 +74,18 @@ class AdminPanel:
         def admin_settings():
             return render_template('admin-settings.html')
 
+        # Logs page
+        @bp.route('/admin/logs')
+        def admin_logs():
+            logs = self.communication_log.get_logs()
+            return render_template('admin-logs.html', logs=logs)
+
         # API endpoints
+        @bp.route('/api/v1/logs/download')
+        def api_download_logs():
+            logs = self.communication_log.get_logs()
+            return jsonify(logs)
+
         @bp.route('/api/v1/system/status')
         def api_system_status():
             return jsonify(self.system_monitor.get_system_status())

--- a/src/admin/templates/admin-base.html
+++ b/src/admin/templates/admin-base.html
@@ -24,6 +24,7 @@
                 <a href="/admin" class="nav-link">Dashboard</a>
                 <a href="/admin/models" class="nav-link">Models</a>
                 <a href="/admin/settings" class="nav-link">Settings</a>
+                <a href="{{ url_for('admin.admin_logs') }}" class="nav-link">Logs</a>
                 <a href="/" class="nav-link">Main App</a>
                 <a href="/docs" class="nav-link">API Docs</a>
             </div>

--- a/src/admin/templates/admin-logs.html
+++ b/src/admin/templates/admin-logs.html
@@ -1,0 +1,56 @@
+{% extends "admin-base.html" %}
+
+{% block title %}Logs - WhisperAppliance Admin{% endblock %}
+
+{% block content %}
+<!-- Page Header -->
+<div class="page-header">
+    <h1 class="page-title">System Logs</h1>
+    <p class="page-subtitle">View system communication logs</p>
+</div>
+
+<!-- Logs Display -->
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">📄 Communication Log Entries</h3>
+        <div class="card-actions">
+            <a href="{{ url_for('admin.api_download_logs') }}" class="btn btn-primary" download="communication_logs.json">
+                Download Logs (JSON)
+            </a>
+        </div>
+    </div>
+    <div class="card-body">
+        {% if logs %}
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Timestamp</th>
+                        <th>User Input</th>
+                        <th>Model</th>
+                        <th>Response</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for log_entry in logs %}
+                        <tr>
+                            <td>{{ log_entry.timestamp }}</td>
+                            <td>{{ log_entry.user_input }}</td>
+                            <td>{{ log_entry.model }}</td>
+                            <td>{{ log_entry.response }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p>No log entries found.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+// Any specific JS for the logs page can go here.
+// For now, the download is a direct link, so no JS is strictly needed for that.
+</script>
+{% endblock %}


### PR DESCRIPTION
- Added a new 'Logs' section to the admin panel to display communication logs.
- Implemented functionality to view logs in a table and download them as a JSON file.
- Updated admin navigation to include a link to the new Logs section.